### PR TITLE
fix: 🐛 Background Color / FlexBox

### DIFF
--- a/alucio/components/Virtual/VirtualExchange.tsx
+++ b/alucio/components/Virtual/VirtualExchange.tsx
@@ -23,8 +23,6 @@ const styles = StyleSheet.create({
     zIndex: 0,
   },
   container: {
-    flexGrow: 1,
-    backgroundColor: luxColors.basicBlack.primary,
     flex: 10,
   },
   contentContainer: {


### PR DESCRIPTION
Just a small fix. (Layout Related)

Basically this PR is a change from this:

<img width="1680" alt="Screen Shot 2020-08-05 at 12 49 34 AM" src="https://user-images.githubusercontent.com/9094553/89370267-b2c70200-d6b6-11ea-89db-45dc417e8460.png">

to this:

<img width="1680" alt="Screen Shot 2020-08-05 at 12 40 25 AM" src="https://user-images.githubusercontent.com/9094553/89370256-aa6ec700-d6b6-11ea-9192-4f00b3e9402d.png">


